### PR TITLE
Add basic WPF chat interface with dummy responses

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -6,7 +6,26 @@
         xmlns:local="clr-namespace:codex_windows_desktop_client"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
-    <Grid>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
+        <!-- Project folder selection -->
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,10">
+            <TextBox x:Name="ProjectPathTextBox" Width="600" Margin="0,0,5,0"/>
+            <Button Content="Browse..." Width="80" Click="BrowseButton_Click"/>
+        </StackPanel>
+
+        <!-- Chat messages -->
+        <ListBox x:Name="ChatList" Grid.Row="1"/>
+
+        <!-- Input area -->
+        <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="0,10,0,0">
+            <TextBox x:Name="InputTextBox" Width="600" Margin="0,0,5,0"/>
+            <Button Content="Send" Width="80" Click="SendButton_Click"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,24 +1,41 @@
-﻿using System.Text;
+using System.Collections.ObjectModel;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
-namespace codex_windows_desktop_client
+namespace codex_windows_desktop_client;
+
+/// <summary>
+/// Interaction logic for MainWindow.xaml
+/// </summary>
+public partial class MainWindow : Window
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
-    public partial class MainWindow : Window
+    private readonly ObservableCollection<string> _messages = new();
+
+    public MainWindow()
     {
-        public MainWindow()
+        InitializeComponent();
+        ChatList.ItemsSource = _messages;
+    }
+
+    private void SendButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(InputTextBox.Text))
+            return;
+
+        var userMessage = InputTextBox.Text.Trim();
+        _messages.Add($"User: {userMessage}");
+        InputTextBox.Clear();
+
+        // Dummy response from Codex
+        _messages.Add("Codex: This is a dummy response.");
+    }
+
+    private void BrowseButton_Click(object sender, RoutedEventArgs e)
+    {
+        using var dialog = new System.Windows.Forms.FolderBrowserDialog();
+        if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
         {
-            InitializeComponent();
+            ProjectPathTextBox.Text = dialog.SelectedPath;
         }
     }
 }
+

--- a/codex-windows-desktop-client.csproj
+++ b/codex-windows-desktop-client.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Add simple chat UI with project folder selector
- Wire up send/browse buttons to show dummy Codex responses
- Enable Windows Forms in project for folder selection dialog

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6895e9e9cf0c8320aa08eb8c6643c845